### PR TITLE
Fixing some links

### DIFF
--- a/about.md
+++ b/about.md
@@ -13,7 +13,7 @@ Full-stack web developer excited about interdisciplinary collaboration, open sou
 I recently graduated from Dev Bootcamp and am seeking opportunities to keep learning and growing. I focus on building beautiful and deployable projects with extensible data structures and sensible user interfaces. Explore [my projects](/portfolio) and [ongoing work on GitHub](https://github.com/camillevilla).
 
 #### digital humanist
-I love the thoughtful, critical work that lives at the intersection of humanistic inquiry, art, computation, and other digital tools. As hire #3 of the [Digital Humanities at Berkeley](https://digitalhumanities.berkeley.edu) program, I facilitated communities of practice, supported curriculum development, provided technical consulting, and worked with professors and graduate students to develop projects and grant proposals. [Learn more about my past DH work](/dhb)
+I love the thoughtful, critical work that lives at the intersection of humanistic inquiry, art, computation, and other digital tools. As hire #3 of the [Digital Humanities at Berkeley](http://digitalhumanities.berkeley.edu) program, I facilitated communities of practice, supported curriculum development, provided technical consulting, and worked with professors and graduate students to develop projects and grant proposals. [Learn more about my past DH work](/dhb)
 
 #### open knowledge advocate
 I like digging into research and empowering others to do the same. I used to teach [a class on research skills, archives, libraries, and databases](http://historicalresearchworkshop.com/?page_id=2). I draw inspiration from movements around open access publishing, open culture, and open source software.
@@ -29,9 +29,9 @@ I’m interested in what it means to be “technical” in various fields. Build
 ### Projects I like:
 - [The Internet Archive](https://www.archive.org)
 - [Digital Public Library of America](https://www.dp.la)
-- [Railsbridge](https://www.railsbridge.org)
-- [Women Who Code](https://www.womenwhocode.com) (come say hi at the [San Francisco](https://www.meetup.com/Women-Who-Code-SF/) and [East Bay](https://www.meetup.com/Women-Who-Code-East-Bay/) chapters)
-- [The Programming Historian](https://www.programminghistorian.org)
+- [Railsbridge](http://www.railsbridge.org)
+- [Women Who Code](http://www.womenwhocode.com) (come say hi at the [San Francisco](https://www.meetup.com/Women-Who-Code-SF/) and [East Bay](https://www.meetup.com/Women-Who-Code-East-Bay/) chapters)
+- [The Programming Historian](http://www.programminghistorian.org)
 - [DiRT Directory](https://www.dirtdirectory.org)
-- [CommonGarden](https://www.commongarden.org)
+- [CommonGarden](http://www.commongarden.org)
 - [OpenHatch](https://openhatch.org/) 


### PR DESCRIPTION
Some of the https links did not work (at least in FireFox), so I changed some of them back. I wonder why it is Jekyll seems to use your root url in place of <www>, for links like your twitter and github accts, i'm sure there's some reason..